### PR TITLE
manifest: use Zephyr main branch

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -12,5 +12,5 @@ manifest:
   projects:
     - name: zephyr
       remote: zephyrproject-rtos
-      revision: master
+      revision: main
       import: true


### PR DESCRIPTION
Zephyr now uses main instead of master.