### PR TITLE
ci: Remove cache

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,16 +12,6 @@ jobs:
         with:
           path: example-application
 
-      - name: Cache Zephyr
-        uses: actions/cache@v2
-        with:
-          path: |
-            bootloader
-            modules
-            tools
-            zephyr
-          key: ${{ hashFiles('example-application/west.yml') }}
-
       - name: Initialize
         working-directory: example-application
         run: |


### PR DESCRIPTION
It doesn't make sense to cache the zephyr dir as this will
always be changing.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>