### PR TITLE
manifest: pin to Zephyr v2.6.0

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -12,5 +12,5 @@ manifest:
   projects:
     - name: zephyr
       remote: zephyrproject-rtos
-      revision: main
+      revision: v2.6.0
       import: true


### PR DESCRIPTION
Pin to Zephyr v2.6.0 for the v2.6.0 release of the example-application. The current v2.6.0 tag should be deleted and re-created pointing to this commit once merged. Manifest has to be updated to point to `main` afterwards.