### PR TITLE
manifest: Switch back to main after release

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -12,5 +12,5 @@ manifest:
   projects:
     - name: zephyr
       remote: zephyrproject-rtos
-      revision: v2.6.0
+      revision: main
       import: true


### PR DESCRIPTION
Switch back to pointing to main after the v2.6.0 release.

Signed-off-by: Carles Cufi <carles.cufi@nordicsemi.no>