### PR TITLE
workflow: add /opt/toolchains to CMAKE_PREFIX_PATH in environment.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,6 +6,8 @@ jobs:
   build:
     runs-on: ubuntu-latest
     container: zephyrprojectrtos/ci:latest
+    env:
+      CMAKE_PREFIX_PATH: /opt/toolchains
     steps:
       - name: Checkout
         uses: actions/checkout@v2


### PR DESCRIPTION
Fixes: #39270

The latest zephyrprojectrtos/ci no longer sets ZEPHYR_SDK_INSTALL_DIR
in the environment and doesn't register the Zephyr-SDK as a CMake
package in the CMake package registry.

To ensure the the Zephyr SDK can be correctly discovered by
find_package(Zephyr-sdk) we add `/opt/toolchains` to the
CMAKE_PREFIX_PATH environment variable which is a list containing
additional search prefixes for the `find_package()` function.

Signed-off-by: Torsten Rasmussen <Torsten.Rasmussen@nordicsemi.no>