### PR TITLE
app, drivers: migrate includes to <zephyr/...>

### DIFF
--- a/app/src/main.c
+++ b/app/src/main.c
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <zephyr.h>
+#include <kernel.h>
 #include <drivers/sensor.h>
 
 #include "app_version.h"

--- a/app/src/main.c
+++ b/app/src/main.c
@@ -3,12 +3,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <kernel.h>
-#include <drivers/sensor.h>
+#include <zephyr/kernel.h>
+#include <zephyr/drivers/sensor.h>
 
 #include "app_version.h"
 
-#include <logging/log.h>
+#include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(main, CONFIG_APP_LOG_LEVEL);
 
 void main(void)

--- a/drivers/sensor/examplesensor/examplesensor.c
+++ b/drivers/sensor/examplesensor/examplesensor.c
@@ -5,11 +5,11 @@
 
 #define DT_DRV_COMPAT zephyr_examplesensor
 
-#include <device.h>
-#include <drivers/gpio.h>
-#include <drivers/sensor.h>
+#include <zephyr/device.h>
+#include <zephyr/drivers/gpio.h>
+#include <zephyr/drivers/sensor.h>
 
-#include <logging/log.h>
+#include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(examplesensor, CONFIG_SENSOR_LOG_LEVEL);
 
 struct examplesensor_data {


### PR DESCRIPTION
Zephyr includes are now prefixed with <zephyr/...>. While the old path
can still be used when CONFIG_LEGACY_INCLUDE_PATH=y, it's better to be
prepared for the future.