### PR TITLE
ci/readme: remove usage of -s legacy option

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Build firmware
         working-directory: example-application
         run: |
-          west build -b custom_plank -s app
+          west build -b custom_plank app
 
       - name: Archive firmware
         uses: actions/upload-artifact@v2

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ west update
 The application can be built by running:
 
 ```shell
-west build -b $BOARD -s app
+west build -b $BOARD app
 ```
 
 where `$BOARD` is the target board. The `custom_plank` board found in this
@@ -57,7 +57,7 @@ appropriate overlay is provided (see `app/boards`).
 A sample debug configuration is also provided. You can apply it by running:
 
 ```shell
-west build -b $BOARD -s app -- -DOVERLAY_CONFIG=debug.conf
+west build -b $BOARD app -- -DOVERLAY_CONFIG=debug.conf
 ```
 
 Note that you may also use it together with `rtt.conf` if using Segger RTT. Once


### PR DESCRIPTION
-s/--source is a legacy option. There's a proposal to actually use it
for something else in Zephyr now:

https://github.com/zephyrproject-rtos/zephyr/pull/40669

Let's update README.