### PR TITLE
drivers: sensor: examplesensor: use DT_HAS_* helper

### DIFF
--- a/app/prj.conf
+++ b/app/prj.conf
@@ -4,4 +4,3 @@
 # This file contains selected Kconfig options for the application.
 
 CONFIG_SENSOR=y
-CONFIG_EXAMPLESENSOR=y

--- a/drivers/sensor/examplesensor/Kconfig
+++ b/drivers/sensor/examplesensor/Kconfig
@@ -3,6 +3,7 @@
 
 config EXAMPLESENSOR
 	bool "Example sensor"
-	depends on GPIO
+	default y
+	depends on GPIO && DT_HAS_ZEPHYR_EXAMPLESENSOR_ENABLED
 	help
 	  Enable example sensor


### PR DESCRIPTION
Make zephyr,examplesensor driver option dependent on it being defined in
Kconfig and set its default based on DT status as well