### PR TITLE
Remove usage of deprecated label property and use select

### DIFF
--- a/app/boards/nucleo_f302r8.overlay
+++ b/app/boards/nucleo_f302r8.overlay
@@ -12,7 +12,6 @@
 / {
 	examplesensor0: examplesensor_0 {
 		compatible = "zephyr,examplesensor";
-		label = "EXAMPLESENSOR_0";
 		input-gpios = <&gpioc 13 (GPIO_PULL_UP | GPIO_ACTIVE_LOW)>;
 	};
 };

--- a/boards/arm/custom_plank/custom_plank.dts
+++ b/boards/arm/custom_plank/custom_plank.dts
@@ -18,7 +18,6 @@
 
 	examplesensor0: examplesensor_0 {
 		compatible = "zephyr,examplesensor";
-		label = "EXAMPLESENSOR_0";
 		input-gpios = <&gpio0 11 (GPIO_PULL_UP | GPIO_ACTIVE_LOW)>;
 	};
 };

--- a/drivers/sensor/examplesensor/Kconfig
+++ b/drivers/sensor/examplesensor/Kconfig
@@ -4,6 +4,7 @@
 config EXAMPLESENSOR
 	bool "Example sensor"
 	default y
-	depends on GPIO && DT_HAS_ZEPHYR_EXAMPLESENSOR_ENABLED
+	depends on DT_HAS_ZEPHYR_EXAMPLESENSOR_ENABLED
+	select GPIO
 	help
 	  Enable example sensor

--- a/dts/bindings/sensor/zephyr,examplesensor.yaml
+++ b/dts/bindings/sensor/zephyr,examplesensor.yaml
@@ -9,7 +9,6 @@ description: |
 
     examplesensor {
         compatible = "zephyr,examplesensor";
-        label = "EXAMPLESENSOR";
         input-gpios = <&gpio0 0 (GPIO_PULL_UP | GPIO_ACTIVE_LOW)>;
     };
 


### PR DESCRIPTION
Devicetree label property has been deprecated, so remove its usage. Also use `select` in sensor's Kconfig, following latest upstream practices.