### PR TITLE
modules: Set module name

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,8 +1,24 @@
 # Copyright (c) 2021 Nordic Semiconductor ASA
+# Copyright (c) 2022 Legrand North America, LLC.
 # SPDX-License-Identifier: Apache-2.0
 #
 # This CMake file is picked by the Zephyr build system because it is defined
 # as the module CMake entry point (see zephyr/module.yml).
+
+
+# Verify the module name is set correctly
+set(expected_module_name "example-application")
+if(NOT "${module_name}" STREQUAL ${expected_module_name})
+  message(FATAL_ERROR "
+    ------------------------------------------------------------------------
+    A module configuration error has occurred.
+    
+    This module is named '${module_name}' when '${expected_module_name}' is expected. 
+    Verify `module.yml` contains the line 'name: ${expected_module_name}'.
+    ------------------------------------------------------------------------")
+endif()
+unset(expected_module_name)
+
 
 zephyr_include_directories(include)
 

--- a/zephyr/module.yml
+++ b/zephyr/module.yml
@@ -1,6 +1,8 @@
 # Copyright (c) 2021 Nordic Semiconductor ASA
+# Copyright (c) 2022 Legrand North America, LLC.
 # SPDX-License-Identifier: Apache-2.0
 
+name: example-application
 build:
   # Path to the Kconfig file that will be sourced into Zephyr Kconfig tree under
   # Zephyr > Modules > example-application. Path is relative from root of this


### PR DESCRIPTION
Follow the Zephyr recommendation to explicitly set the module name in `module.yml`. Add a build check in the module-level CMakeLists.txt to verify the value of the build variable ${module_name} is the expected value so that other modules may reference this one without needing to know the path to this module.

Verified by:
1. Successfully building `west build -p always -b custom_plank example-application/app` with the name check and the defaulted name.
2. Unsuccessfully buildng `west build -p always -b custom_plank example-application/app` with the name check and an unexpected name set in `module.yml`
3. Unsuccessfully buildng `west build -p always -b custom_plank example-application/app` with the name check and the expected name set in `module.yml`

Fix #50866

Signed-off-by: Gregory SHUE <gregory.shue@legrand.com>