### PR TITLE
boards: custom_plank: migrate to pinctrl

### DIFF
--- a/boards/arm/custom_plank/custom_plank-pinctrl.dtsi
+++ b/boards/arm/custom_plank/custom_plank-pinctrl.dtsi
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) 2022 Nordic Semiconductor ASA
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&pinctrl {
+	uart0_default: uart0_default {
+		group1 {
+			psels = <NRF_PSEL(UART_TX, 0, 6)>,
+				<NRF_PSEL(UART_RX, 0, 8)>,
+				<NRF_PSEL(UART_RTS, 0, 5)>,
+				<NRF_PSEL(UART_CTS, 0, 7)>;
+		};
+	};
+
+	uart0_sleep: uart0_sleep {
+		group1 {
+			psels = <NRF_PSEL(UART_TX, 0, 6)>,
+				<NRF_PSEL(UART_RX, 0, 8)>,
+				<NRF_PSEL(UART_RTS, 0, 5)>,
+				<NRF_PSEL(UART_CTS, 0, 7)>;
+			low-power-enable;
+		};
+	};
+
+};

--- a/boards/arm/custom_plank/custom_plank.dts
+++ b/boards/arm/custom_plank/custom_plank.dts
@@ -5,6 +5,7 @@
 
 /dts-v1/;
 #include <nordic/nrf52840_qiaa.dtsi>
+#include "custom_plank-pinctrl.dtsi"
 
 / {
 	model = "Custom Plank Board";
@@ -31,8 +32,7 @@
 	status = "okay";
 
 	current-speed = <115200>;
-	tx-pin = <6>;
-	rx-pin = <8>;
-	rts-pin = <5>;
-	cts-pin = <7>;
+	pinctrl-0 = <&uart0_default>;
+	pinctrl-1 = <&uart0_sleep>;
+	pinctrl-names = "default", "sleep";
 };


### PR DESCRIPTION
The board still used deprecated nRF *-pin properties, migrate it to pinctrl.

Signed-off-by: Gerard Marull-Paretas <gerard.marull@nordicsemi.no>