### PR TITLE
west.yml: remove 'self: path:'

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -3,7 +3,6 @@
 
 manifest:
   self:
-    path: example-application
     west-commands: scripts/west-commands.yml
 
   remotes:


### PR DESCRIPTION
This makes it easier to rename this repository and use it under its new name. For example, with this patch, if you push the repository to GitHub user 'foo' as repository 'bar', you can do:

```
  west init -m https://github.com/foo/bar my-workspace
```

And you will get:

  - my-workspace/.west/config says manifest.path is 'bar'
  - my-workspace/bar exists as a git repository

By contrast, with the current 'self: path:' setting, you will instead get:

  - my-workspace/.west/config says manifest.path is 'example-application'
  - my-workspace/example-application exists as a git repository

Let's let people name this repository whatever they want, and get the expected results, instead of forcing the name example-application

Signed-off-by: Marti Bolivar <marti.bolivar@nordicsemi.no>