### PR TITLE
app: adjust main definition 

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,6 +1,10 @@
 name: Build
 
-on: [push, pull_request]
+on:
+  push:
+  pull_request:
+  schedule:
+    - cron: "0 0 * * *"
 
 jobs:
   build:

--- a/app/src/main.c
+++ b/app/src/main.c
@@ -11,7 +11,7 @@
 #include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(main, CONFIG_APP_LOG_LEVEL);
 
-void main(void)
+int main(void)
 {
 	int ret;
 	const struct device *sensor;
@@ -21,7 +21,7 @@ void main(void)
 	sensor = DEVICE_DT_GET(DT_NODELABEL(examplesensor0));
 	if (!device_is_ready(sensor)) {
 		LOG_ERR("Sensor not ready");
-		return;
+		return 0;
 	}
 
 	while (1) {
@@ -30,18 +30,20 @@ void main(void)
 		ret = sensor_sample_fetch(sensor);
 		if (ret < 0) {
 			LOG_ERR("Could not fetch sample (%d)", ret);
-			return;
+			return 0;
 		}
 
 		ret = sensor_channel_get(sensor, SENSOR_CHAN_PROX, &val);
 		if (ret < 0) {
 			LOG_ERR("Could not get sample (%d)", ret);
-			return;
+			return 0;
 		}
 
 		printk("Sensor value: %d\n", val.val1);
 
 		k_sleep(K_MSEC(1000));
 	}
+
+	return 0;
 }
 


### PR DESCRIPTION
Zephyr now requires `int main(void)`. Main must return 0, all other
values are reserved.

Schedule a daily build, so that we can quickly spot regressions in the
application due to changes in Zephyr.