### PR TITLE
app: use extra_overlay_confs

### DIFF
--- a/app/sample.yaml
+++ b/app/sample.yaml
@@ -12,4 +12,5 @@ common:
 tests:
   app.default: {}
   app.debug:
-    extra_args: OVERLAY_CONFIG="debug.conf"
+    extra_overlay_confs:
+      - debug.conf


### PR DESCRIPTION
Using OVERLAY_CONFIG in extra_args is deprecated in favor of
extra_overlay_confs.