### PR TITLE
fix: debug command in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ A sample debug configuration is also provided. To apply it, run the following
 command:
 
 ```shell
-west build -b $BOARD app -- -DOVERLAY_CONFIG=debug.conf
+west build -b $BOARD app -- -DOVERLAY_CONFIG="debug.conf"
 ```
 
 Once you have built the application, run the following command to flash it:


### PR DESCRIPTION
Trying to build the debug configuration as currently described in the readme file results in an error.

In a Python virtual environment under Windows, CMake first raises a warning:

```
CMake Warning:
  Ignoring extra path from command line:

   ".conf"
```

And then fails with the following error:

```
CMake Error at C:/Zephyr/my-workspace/zephyr/cmake/modules/kconfig.cmake:275 (message):
  File not found:
  C:/Zephyr/my-workspace/example-application/app/debug
```

To fix this, the filename should be enclosed in double quotes.