### PR TITLE
readme: Switch to app subdirectory before building

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,12 @@ west update
 
 ### Building and running
 
+Now enter the directory west has just created:
+
+```shell
+cd example-application
+```
+
 To build the application, run the following command:
 
 ```shell


### PR DESCRIPTION
Without this, `west` complains that `app` is not found and refuses to compile.