### PR TITLE
generate CHANGELOG.md from git history

### DIFF
--- a/.chglog/CHANGELOG.tpl.md
+++ b/.chglog/CHANGELOG.tpl.md
@@ -1,0 +1,19 @@
+{{ range .Versions }}
+## [{{ .Tag.Name }}] - {{ datetime "2006-01-02" .Tag.Date }}
+{{ range .CommitGroups -}}
+### {{ .Title }}
+{{ range .Commits -}}
+- {{ if .Scope }}**{{ .Scope }}:** {{ end }}{{ .Subject }}
+{{ end }}
+{{ end -}}
+
+{{- if .NoteGroups -}}
+{{ range .NoteGroups -}}
+### {{ .Title }}
+{{ range .Notes }}
+{{ .Body }}
+{{ end }}
+{{ end -}}
+{{ end -}}
+{{ end -}}
+

--- a/.chglog/config.yml
+++ b/.chglog/config.yml
@@ -1,0 +1,35 @@
+style: none
+template: CHANGELOG.tpl.md
+info:
+  title: CHANGELOG
+  repository_url: ""
+options:
+  commits:
+    # filters:
+    #   Type:
+    #     - feat
+    #     - fix
+    #     - perf
+    #     - refactor
+  commit_groups:
+    title_maps:
+      feat: Features
+      fix: Bug Fixes
+      refactor: Code Refactoring
+      docs: Documentation
+      style: Formatting
+      test: Tests
+      ci: CI
+      chore: Tooling/Configuration/Other
+  commit_filters:
+    exclude:
+    - Merge branch '{{.Branch}}' of {{.RepoURL}} into {{.Branch}}
+    - Merge branch '{{.Branch}}' into {{.Branch}}
+  header:
+    pattern: "^(\\w*)\\:\\s(.*)$"
+    pattern_maps:
+      - Type
+      - Subject
+  notes:
+    keywords:
+      - BREAKING CHANGE

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
+
+## [v0.0.0]
+Initial release

--- a/scripts/get_latest_version.sh
+++ b/scripts/get_latest_version.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+latest_version=$(git tag --list | grep -E '^v([0-9]+\.){1,3}[0-9]+$' | sort -V | tail -n 1)
+
+# If no versions found, set it to v0.0.0
+if [ -z "$latest_version" ]; then
+    latest_version="v0.0.0"
+fi
+
+echo $latest_version

--- a/scripts/release_notes.sh
+++ b/scripts/release_notes.sh
@@ -1,0 +1,70 @@
+#!/bin/bash
+
+set -e
+
+create_tag=false
+new_version=""
+
+while (( "$#" )); do
+  case "$1" in
+    -t|--create-tag)
+      create_tag=true
+      shift
+      ;;
+    -n|--new-version)
+      if [ -n "$2" ] && [ ${2:0:1} != "-" ]; then
+        new_version="$2"
+        shift 2
+      else
+        echo "Error: The argument for '--new-version' is missing" >&2
+        exit 1
+      fi
+      ;;
+    *)
+      echo "Usage: $0 [--create-tag] [--new-version vx.x.x]"
+      shift
+      exit 0
+      ;;
+  esac
+done
+
+cleanup() {
+  rm -f CHANGELOG.md.part1 CHANGELOG.md.part2
+}
+
+trap cleanup EXIT
+
+last_version=$(bash "$(dirname "$0")/get_latest_version.sh")
+echo "Last version: $last_version"
+
+if [[ -z "$new_version" ]]; then
+  # Increment the patch version by 1 if new_version is not provided
+  if [[ "$last_version" == "v0.0.0" ]]; then
+    new_version="v0.0.1"
+  else
+    new_version=$(echo $last_version | awk -F. '{$NF++; print}' OFS=.)
+  fi
+fi
+
+echo "Generating CHANGELOG.md using commit history from $last_version till $new_version"
+git_changelog=$(git-chglog --next-tag "$new_version" "$new_version")
+
+split_position=$(grep -n -m 1 "^## " CHANGELOG.md | cut -d: -f1)
+head -n $(($split_position - 2)) CHANGELOG.md > CHANGELOG.md.part1
+tail -n +$split_position CHANGELOG.md > CHANGELOG.md.part2
+
+cat CHANGELOG.md.part1 > CHANGELOG.md
+echo "$git_changelog" >> CHANGELOG.md
+echo "" >> CHANGELOG.md
+cat CHANGELOG.md.part2 >> CHANGELOG.md
+
+if $create_tag; then
+  echo "Committing the updated CHANGELOG.md"
+  git add CHANGELOG.md
+  git commit -m "release: $new_version"
+
+  echo "Creating a new tag for the release"
+  git tag "$new_version"
+else
+  echo "Use 'git diff CHANGELOG.md' to display"
+fi


### PR DESCRIPTION
generate a changelog from git history using git-chglog. Make sure to have git-chglog installed.

release notes can be generated using `./scripts/release_notes.sh`. Add the `--create-tag` option to commit the CHANGELOG and create a git tag.

If no version is specified with `--new-version vX.X.X`, the new version is automatically generated by incrementing the patch number.

Note: this doesn't take into account the app VERSION file that has been recently added. This solution only relies on git tags.