### PR TITLE
ci: use shallow fetch and no tags

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,7 +22,7 @@ jobs:
         working-directory: example-application
         run: |
           west init -l .
-          west update
+          west update -o=--depth=1 -n
 
       - name: Build firmware
         working-directory: example-application


### PR DESCRIPTION
Add a couple flags to west update to do shallow fetch for both the main repo and modules, and don't fetch any tags. Should speed things up a bit by only fetching the target version code for all modules.