### PR TITLE
boards: custom_plank: enable gpiote

### DIFF
--- a/boards/arm/custom_plank/custom_plank.dts
+++ b/boards/arm/custom_plank/custom_plank.dts
@@ -27,6 +27,10 @@
 	gpio-as-nreset;
 };
 
+&gpiote {
+	status = "okay";
+};
+
 &gpio0 {
 	status = "okay";
 };


### PR DESCRIPTION
The gpiote node has to be enabled for the board to build since the latest upstream nrfx hal update.