### PR TITLE
ci: align the runner list with the main repository

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os: [ubuntu-22.04, macos-12, macos-14, windows-2022]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout


### PR DESCRIPTION
Use the same runner list as the main repository ones. Originally I meant to just add macos-14 so we cover macOS ARM, which is nice because it runs on qemu-m0 from the brew package, but at this point let's also use explicit version for the other runners too.