### PR TITLE
readme: Added missing directory change in build instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ west update
 To build the application, run the following command:
 
 ```shell
+cd example-application
 west build -b $BOARD app
 ```
 


### PR DESCRIPTION
The current build instructions omit a necessary directory change after creating the workspace.