### PR TITLE
drivers: Use DEVICE_API

### DIFF
--- a/drivers/blink/gpio_led.c
+++ b/drivers/blink/gpio_led.c
@@ -53,7 +53,7 @@ static int blink_gpio_led_set_period_ms(const struct device *dev,
 	return 0;
 }
 
-static const struct blink_driver_api blink_gpio_led_api = {
+static DEVICE_API(blink, blink_gpio_led_api) = {
 	.set_period_ms = &blink_gpio_led_set_period_ms,
 };
 

--- a/drivers/sensor/example_sensor/example_sensor.c
+++ b/drivers/sensor/example_sensor/example_sensor.c
@@ -46,7 +46,7 @@ static int example_sensor_channel_get(const struct device *dev,
 	return 0;
 }
 
-static const struct sensor_driver_api example_sensor_api = {
+static DEVICE_API(sensor, example_sensor_api) = {
 	.sample_fetch = &example_sensor_sample_fetch,
 	.channel_get = &example_sensor_channel_get,
 };

--- a/include/app/drivers/blink.h
+++ b/include/app/drivers/blink.h
@@ -82,10 +82,9 @@ __syscall int blink_set_period_ms(const struct device *dev,
 static inline int z_impl_blink_set_period_ms(const struct device *dev,
 					     unsigned int period_ms)
 {
-	const struct blink_driver_api *api =
-		(const struct blink_driver_api *)dev->api;
+	__ASSERT_NO_MSG(DEVICE_API_IS(blink, dev));
 
-	return api->set_period_ms(dev, period_ms);
+	return DEVICE_API_GET(blink, dev)->set_period_ms(dev, period_ms);
 }
 
 /**

--- a/west.yml
+++ b/west.yml
@@ -12,7 +12,7 @@ manifest:
   projects:
     - name: zephyr
       remote: zephyrproject-rtos
-      revision: main
+      revision: pull/72293/head
       import:
         # By using name-allowlist we can clone only the modules that are
         # strictly needed by the application.

--- a/west.yml
+++ b/west.yml
@@ -12,7 +12,7 @@ manifest:
   projects:
     - name: zephyr
       remote: zephyrproject-rtos
-      revision: pull/72293/head
+      revision: main
       import:
         # By using name-allowlist we can clone only the modules that are
         # strictly needed by the application.


### PR DESCRIPTION
Demonstrate `DEVICE_API` usage for `sensor_driver_api` and `blink_driver_api`.

Upstream PR https://github.com/zephyrproject-rtos/zephyr/pull/71773