### PR TITLE
ci: use actions/checkout@v4 and actions/setup-python@v5

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,12 +15,12 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           path: example-application
 
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: 3.11
 


### PR DESCRIPTION
Use actions/checkout@v4 and actions/setup-python@v5 when checking out and setting up the example-application repository in CI. The new versions uses Node20 instead of the deprecated Node16.

See https://github.blog/changelog/2024-03-07-github-actions-all-actions-will-run-on-node20-instead-of-node16-by-default/ for more information.