### PR TITLE
ci: only attempt to deploy the built documentation in the upstream repo

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -34,17 +34,23 @@ jobs:
           mv _build_sphinx/html/* deploy
 
       - name: Setup pages
-        if: github.event_name != 'pull_request'
+        if: |
+          github.event_name != 'pull_request' &&
+          github.repository == 'zephyrproject-rtos/example-application'
         uses: actions/configure-pages@v4
 
       - name: Upload pages artifact
-        if: github.event_name != 'pull_request'
+        if: |
+          github.event_name != 'pull_request' &&
+          github.repository == 'zephyrproject-rtos/example-application'
         uses: actions/upload-pages-artifact@v3
         with:
           path: doc/deploy
 
       - name: Upload artifacts
-        if: github.event_name == 'pull_request'
+        if: |
+          github.event_name == 'pull_request' &&
+          github.repository == 'zephyrproject-rtos/example-application'
         uses: actions/upload-artifact@v4
         with:
           path: doc/deploy
@@ -52,7 +58,9 @@ jobs:
   deploy:
     runs-on: ubuntu-22.04
     needs: build
-    if: github.event_name != 'pull_request'
+    if: |
+      github.event_name != 'pull_request' &&
+      github.repository == 'zephyrproject-rtos/example-application'
     permissions:
       pages: write
       id-token: write


### PR DESCRIPTION
Only attempt to deploy the documentation when running in the zephyrproject-rtos/example-application repository. This avoid deployment failure for downstream forks with CI enabled.