### PR TITLE
boards: custom_plank: use DT to enable DCDC

### DIFF
--- a/boards/vendor/custom_plank/Kconfig
+++ b/boards/vendor/custom_plank/Kconfig
@@ -1,8 +1,0 @@
-# Copyright (c) 2021 Nordic Semiconductor ASA
-# SPDX-License-Identifier: Apache-2.0
-
-config BOARD_ENABLE_DCDC
-	bool "Enable DCDC mode"
-	select SOC_DCDC_NRF52X
-	default y
-	depends on BOARD_CUSTOM_PLANK

--- a/boards/vendor/custom_plank/custom_plank.dts
+++ b/boards/vendor/custom_plank/custom_plank.dts
@@ -29,6 +29,14 @@
 	};
 };
 
+&reg0 {
+	status = "okay";
+};
+
+&reg1 {
+	regulator-initial-mode = <NRF5X_REG_MODE_DCDC>;
+};
+
 &uicr {
 	gpio-as-nreset;
 };

--- a/boards/vendor/custom_plank/pre_dt_board.cmake
+++ b/boards/vendor/custom_plank/pre_dt_board.cmake
@@ -1,0 +1,7 @@
+# Copyright (c) 2024 Nordic Semiconductor
+# SPDX-License-Identifier: Apache-2.0
+
+# Suppress "unique_unit_address_if_enabled" to handle the following overlaps:
+# - power@40000000 & clock@40000000 & bprot@40000000
+# - acl@4001e000 & flash-controller@4001e000
+list(APPEND EXTRA_DTC_FLAGS "-Wno-unique_unit_address_if_enabled")


### PR DESCRIPTION
custom_plank is a sample custom board template usable on nRF52840DK. The DCDC module on the nRF52840 SoC is now enabled using DT, the Kconfig options are deprecated, so let's keep up to date.