### PR TITLE
west.yml: switch to cmsis_6

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -17,6 +17,6 @@ manifest:
         # By using name-allowlist we can clone only the modules that are
         # strictly needed by the application.
         name-allowlist:
-          - cmsis      # required by the ARM port
+          - cmsis_6    # required by the ARM port for Cortex-M
           - hal_nordic # required by the custom_plank board (Nordic based)
           - hal_stm32  # required by the nucleo_f302r8 board (STM32 based)


### PR DESCRIPTION
Cortex-M now requires using the cmsis_6 module.