### PR TITLE
ci: bump Python to v3.12

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: 3.11
+          python-version: 3.12
 
       - name: Setup Zephyr project
         uses: zephyrproject-rtos/action-zephyr-setup@v1


### PR DESCRIPTION
Bump the version of Python used in CI to v3.12.

Fixes: https://github.com/zephyrproject-rtos/example-application/actions/runs/15768565528