### PR TITLE
ci: add compliance script checks to example repo

### DIFF
--- a/.checkpatch.conf
+++ b/.checkpatch.conf
@@ -1,0 +1,32 @@
+--emacs
+--summary-file
+--show-types
+--max-line-length=100
+--min-conf-desc-length=1
+--typedefsfile=scripts/checkpatch/typedefsfile
+
+--ignore PRINTK_WITHOUT_KERN_LEVEL
+--ignore SPLIT_STRING
+--ignore VOLATILE
+--ignore CONFIG_EXPERIMENTAL
+--ignore PREFER_KERNEL_TYPES
+--ignore PREFER_SECTION
+--ignore AVOID_EXTERNS
+--ignore NETWORKING_BLOCK_COMMENT_STYLE
+--ignore DATE_TIME
+--ignore MINMAX
+--ignore CONST_STRUCT
+--ignore FILE_PATH_CHANGES
+--ignore SPDX_LICENSE_TAG
+--ignore C99_COMMENT_TOLERANCE
+--ignore REPEATED_WORD
+--ignore UNDOCUMENTED_DT_STRING
+--ignore DT_SPLIT_BINDING_PATCH
+--ignore DT_SCHEMA_BINDING_PATCH
+--ignore TRAILING_SEMICOLON
+--ignore COMPLEX_MACRO
+--ignore MULTISTATEMENT_MACRO_USE_DO_WHILE
+--ignore ENOSYS
+--ignore IS_ENABLED_CONFIG
+--ignore EXPORT_SYMBOL
+--ignore COMPARISON_TO_NULL

--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,119 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# Note: The list of ForEachMacros can be obtained using:
+#
+#    git grep -h '^#define [^[:space:]]*FOR_EACH[^[:space:]]*(' include/ \
+#    | sed "s,^#define \([^[:space:]]*FOR_EACH[^[:space:]]*\)(.*$,  - '\1'," \
+#    | sort | uniq
+#
+# References:
+#   - https://clang.llvm.org/docs/ClangFormatStyleOptions.html
+
+---
+BasedOnStyle: LLVM
+AlignConsecutiveMacros: AcrossComments
+AllowShortBlocksOnASingleLine: Never
+AllowShortCaseLabelsOnASingleLine: false
+AllowShortEnumsOnASingleLine: false
+AllowShortFunctionsOnASingleLine: None
+AllowShortIfStatementsOnASingleLine: false
+AllowShortLoopsOnASingleLine: false
+AttributeMacros:
+  - __aligned
+  - __deprecated
+  - __packed
+  - __printf_like
+  - __syscall
+  - __syscall_always_inline
+  - __subsystem
+BitFieldColonSpacing: After
+BreakBeforeBraces: Linux
+ColumnLimit: 100
+ConstructorInitializerIndentWidth: 8
+ContinuationIndentWidth: 8
+ForEachMacros:
+  - 'ARRAY_FOR_EACH'
+  - 'ARRAY_FOR_EACH_PTR'
+  - 'FOR_EACH'
+  - 'FOR_EACH_FIXED_ARG'
+  - 'FOR_EACH_IDX'
+  - 'FOR_EACH_IDX_FIXED_ARG'
+  - 'FOR_EACH_NONEMPTY_TERM'
+  - 'FOR_EACH_FIXED_ARG_NONEMPTY_TERM'
+  - 'RB_FOR_EACH'
+  - 'RB_FOR_EACH_CONTAINER'
+  - 'SYS_DLIST_FOR_EACH_CONTAINER'
+  - 'SYS_DLIST_FOR_EACH_CONTAINER_SAFE'
+  - 'SYS_DLIST_FOR_EACH_NODE'
+  - 'SYS_DLIST_FOR_EACH_NODE_SAFE'
+  - 'SYS_SEM_LOCK'
+  - 'SYS_SFLIST_FOR_EACH_CONTAINER'
+  - 'SYS_SFLIST_FOR_EACH_CONTAINER_SAFE'
+  - 'SYS_SFLIST_FOR_EACH_NODE'
+  - 'SYS_SFLIST_FOR_EACH_NODE_SAFE'
+  - 'SYS_SLIST_FOR_EACH_CONTAINER'
+  - 'SYS_SLIST_FOR_EACH_CONTAINER_SAFE'
+  - 'SYS_SLIST_FOR_EACH_NODE'
+  - 'SYS_SLIST_FOR_EACH_NODE_SAFE'
+  - '_WAIT_Q_FOR_EACH'
+  - '_WAIT_Q_FOR_EACH_SAFE'
+  - 'Z_FOR_EACH'
+  - 'Z_FOR_EACH_ENGINE'
+  - 'Z_FOR_EACH_EXEC'
+  - 'Z_FOR_EACH_FIXED_ARG'
+  - 'Z_FOR_EACH_FIXED_ARG_EXEC'
+  - 'Z_FOR_EACH_IDX'
+  - 'Z_FOR_EACH_IDX_EXEC'
+  - 'Z_FOR_EACH_IDX_FIXED_ARG'
+  - 'Z_FOR_EACH_IDX_FIXED_ARG_EXEC'
+  - 'Z_GENLIST_FOR_EACH_CONTAINER'
+  - 'Z_GENLIST_FOR_EACH_CONTAINER_SAFE'
+  - 'Z_GENLIST_FOR_EACH_NODE'
+  - 'Z_GENLIST_FOR_EACH_NODE_SAFE'
+  - 'STRUCT_SECTION_FOREACH'
+  - 'STRUCT_SECTION_FOREACH_ALTERNATE'
+  - 'TYPE_SECTION_FOREACH'
+  - 'K_SPINLOCK'
+  - 'COAP_RESOURCE_FOREACH'
+  - 'COAP_SERVICE_FOREACH'
+  - 'COAP_SERVICE_FOREACH_RESOURCE'
+  - 'HTTP_RESOURCE_FOREACH'
+  - 'HTTP_SERVER_CONTENT_TYPE_FOREACH'
+  - 'HTTP_SERVICE_FOREACH'
+  - 'HTTP_SERVICE_FOREACH_RESOURCE'
+  - 'I3C_BUS_FOR_EACH_I3CDEV'
+  - 'I3C_BUS_FOR_EACH_I3CDEV_SAFE'
+  - 'I3C_BUS_FOR_EACH_I2CDEV'
+  - 'I3C_BUS_FOR_EACH_I2CDEV_SAFE'
+  - 'MIN_HEAP_FOREACH'
+IfMacros:
+  - 'CHECKIF'
+# Disabled for now, see bug https://github.com/zephyrproject-rtos/zephyr/issues/48520
+#IncludeBlocks: Regroup
+IncludeCategories:
+  - Regex: '^".*\.h"$'
+    Priority: 0
+  - Regex: '^<(assert|complex|ctype|errno|fenv|float|inttypes|limits|locale|math|setjmp|signal|stdarg|stdbool|stddef|stdint|stdio|stdlib|string|tgmath|time|wchar|wctype)\.h>$'
+    Priority: 1
+  - Regex: '^\<zephyr/.*\.h\>$'
+    Priority: 2
+  - Regex: '.*'
+    Priority: 3
+IndentCaseLabels: false
+IndentGotoLabels: false
+IndentWidth: 8
+InsertBraces: true
+InsertNewlineAtEOF: true
+SpaceBeforeInheritanceColon: False
+SpaceBeforeParens: ControlStatementsExceptControlMacros
+SortIncludes: Never
+UseTab: ForContinuationAndIndentation
+WhitespaceSensitiveMacros:
+  - COND_CODE_0
+  - COND_CODE_1
+  - IF_DISABLED
+  - IF_ENABLED
+  - LISTIFY
+  - STRINGIFY
+  - Z_STRINGIFY
+  - DT_FOREACH_PROP_ELEM_SEP

--- a/.github/workflows/compliance.yml
+++ b/.github/workflows/compliance.yml
@@ -1,0 +1,119 @@
+name: Compliance Checks
+
+on: pull_request
+
+permissions:
+  contents: read
+
+jobs:
+  check_compliance:
+    runs-on: ubuntu-24.04
+    name: Run compliance checks on patch series (PR)
+    steps:
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: 3.12
+
+      - name: Checkout the code
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          path: example-application
+          fetch-depth: 0
+
+      - name: Rebase onto the target branch
+        working-directory: example-application
+        env:
+          BASE_REF: ${{ github.base_ref }}
+        run: |
+          git config --global user.email "you@example.com"
+          git config --global user.name "Your Name"
+          git config --global --add safe.directory $PWD
+          git remote -v
+          # Ensure there's no merge commits in the PR
+          [[ "$(git rev-list --merges --count origin/${BASE_REF}..)" == "0" ]] || \
+          (echo "::error ::Merge commits not allowed, rebase instead";false)
+          rm -fr ".git/rebase-apply"
+          rm -fr ".git/rebase-merge"
+          git rebase origin/${BASE_REF}
+          git clean -f -d
+          # debug
+          git log  --pretty=oneline | head -n 10
+
+      - name: Install west
+        shell: bash
+        run: |
+          if ! command -v west &> /dev/null; then
+            echo "west could not be found, installing..."
+            python -m pip install west==1.5.0
+          fi
+
+      - name: Initialize west workspace
+        shell: bash
+        run: |
+          west init -l example-application
+
+      - name: Update west workspace
+        shell: bash
+        run: |
+          west update -o=--depth=1 -n
+
+      - name: Install Python dependencies
+        shell: bash
+        run: |
+          pip install -r zephyr/scripts/requirements-compliance.txt
+
+      - name: Run Compliance Tests
+        continue-on-error: true
+        id: compliance
+        working-directory: example-application
+        env:
+          BASE_REF: ${{ github.base_ref }}
+          UNDEF_KCONFIG_OUTSIDE_ALLOWLIST_FILE:
+            ${{ github.workspace }}/example-application/scripts/undef_kconfig_allowlist.txt
+        run: |
+          export ZEPHYR_BASE=$PWD/../zephyr
+          # debug
+          ls -la
+          git log  --pretty=oneline | head -n 10
+          ./scripts/repo_compliance.py --annotate -e SysbuildKconfig \
+          -c origin/${BASE_REF}..
+
+      - name: upload-results
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+        continue-on-error: true
+        with:
+          name: compliance.xml
+          path: example-application/compliance.xml
+
+      - name: check-warns
+        shell: bash
+        working-directory: example-application
+        run: |
+          if [[ ! -s "compliance.xml" ]]; then
+            exit 1;
+          fi
+
+          warns=("ClangFormat" "LicenseAndCopyrightCheck")
+          files=($(./scripts/repo_compliance.py -l))
+
+          for file in "${files[@]}"; do
+            f="${file}.txt"
+            if [[ -s $f ]]; then
+              results=$(cat $f)
+              results="${results//'%'/'%25'}"
+              results="${results//$'\n'/'%0A'}"
+              results="${results//$'\r'/'%0D'}"
+              if [[ "${warns[@]}" =~ "${file}" ]]; then
+                echo "::warning file=${f}::$results"
+              else
+                echo "::error file=${f}::$results"
+                exit=1
+              fi
+            fi
+          done
+
+          if [ "${exit}" == "1" ]; then
+            exit 1;
+          fi

--- a/.ruff.toml
+++ b/.ruff.toml
@@ -1,0 +1,30 @@
+# Copyright (c) 2024 Basalte bv
+# SPDX-License-Identifier: Apache-2.0
+
+extend = ".ruff-excludes.toml"
+
+line-length = 100
+target-version = "py312"
+
+[lint]
+select = [
+    # zephyr-keep-sorted-start
+    "B",      # flake8-bugbear
+    "E",      # pycodestyle
+    "F",      # pyflakes
+    "I",      # isort
+    "SIM",    # flake8-simplify
+    "UP",     # pyupgrade
+    "W",      # pycodestyle warnings
+    # zephyr-keep-sorted-stop
+]
+
+ignore = [
+    # zephyr-keep-sorted-start
+    "SIM108", # Allow if-else blocks instead of forcing ternary operator
+    # zephyr-keep-sorted-stop
+]
+
+[format]
+quote-style = "preserve"
+line-ending = "lf"

--- a/.yamllint
+++ b/.yamllint
@@ -1,0 +1,16 @@
+# SPDX-License-Identifier: Apache-2.0
+
+extends: default
+
+rules:
+  line-length:
+    max: 100
+  comments:
+    min-spaces-from-content: 1
+  indentation:
+    spaces: 2
+    indent-sequences: consistent
+  document-start:
+    present: false
+  truthy:
+    check-keys: false

--- a/LICENSES/Apache-2.0.txt
+++ b/LICENSES/Apache-2.0.txt
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/LICENSES/README.md
+++ b/LICENSES/README.md
@@ -1,0 +1,10 @@
+> [!IMPORTANT]
+> The license files in this directory are maintained as per the recommendation
+> of the REUSE specification (https://reuse.software/spec-3.3).
+> These are licenses that may apply to some components hosted in the source tree
+> but that do not end up in built binaries
+> (see https://docs.zephyrproject.org/latest/LICENSING.html#zephyr-licensing).
+>
+> These files do _not_ define the license of the Zephyr project itself.
+> Zephyr is licensed under the Apache 2.0 license, as specified in
+> the [LICENSE](/LICENSE) file at the root of the repository.

--- a/dts/bindings/vendor-prefixes.txt
+++ b/dts/bindings/vendor-prefixes.txt
@@ -1,0 +1,18 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 Analog Devices
+# SPDX-License-Identifier: Apache-2.0
+#
+# Device tree binding vendor prefix registry. Keep this list in
+# alphabetical order.
+#
+# This isn't an exhaustive list, but you should add new prefixes to it
+# before using them to avoid name-space collisions.
+#
+# The contents of this file are parsed during documentation generation.
+# Anything that starts with a '#' is treated as a comment and ignored.
+# Non-empty lines should be in this format:
+#
+# <vendor-prefix><TAB><Full name of vendor>
+
+# zephyr-keep-sorted-start
+vendor	Custom Vendor
+# zephyr-keep-sorted-stop

--- a/scripts/example_west_command.py
+++ b/scripts/example_west_command.py
@@ -8,11 +8,11 @@ Example of a west extension in the example-application repository.'''
 
 from west.commands import WestCommand  # your extension must subclass this
 
-class ExampleWestCommand(WestCommand):
 
+class ExampleWestCommand(WestCommand):
     def __init__(self):
         super().__init__(
-            'example-west-command',               # gets stored as self.name
+            'example-west-command',  # gets stored as self.name
             'an example west extension command',  # self.help
             # self.description:
             '''\
@@ -22,21 +22,20 @@ You can split this up into multiple paragraphs and they'll get
 reflowed for you. You can also pass
 formatter_class=argparse.RawDescriptionHelpFormatter when calling
 parser_adder.add_parser() below if you want to keep your line
-endings.''')
+endings.''',
+        )
 
     def do_add_parser(self, parser_adder):
         # This is a bit of boilerplate, which allows you full control over the
         # type of argparse handling you want. The "parser_adder" argument is
         # the return value of an argparse.ArgumentParser.add_subparsers() call.
-        parser = parser_adder.add_parser(self.name,
-                                         help=self.help,
-                                         description=self.description)
+        parser = parser_adder.add_parser(self.name, help=self.help, description=self.description)
 
         # Add some example options using the standard argparse module API.
         parser.add_argument('-o', '--optional', help='an optional argument')
         parser.add_argument('required', help='a required argument')
 
-        return parser           # gets stored as self.parser
+        return parser  # gets stored as self.parser
 
     def do_run(self, args, unknown_args):
         # This gets called when the user runs the command, e.g.:

--- a/scripts/repo_compliance.py
+++ b/scripts/repo_compliance.py
@@ -1,0 +1,40 @@
+#!/bin/env python3
+# Copyright (c) 2026 Analog Devices, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+# This script runs compliance checks on the repository for coding standards.
+# It imports logic from Zephyr's own check_compliance.py script, but overrides
+# checks that are specific to Zephyr's own repository structure
+
+import os
+import sys
+from pathlib import Path
+
+ZEPHYR_BASE = os.environ.get("ZEPHYR_BASE", str(Path(__file__).resolve().parents[2] / "zephyr"))
+sys.path.insert(0, str(Path(ZEPHYR_BASE) / "scripts" / "ci"))
+
+import check_compliance  # noqa: E402
+
+
+class SampleCheck(check_compliance.ComplianceTest):
+    """
+    Example of a custom compliance check that can be added to the CI checks run in this repo.
+    This check simply passes when run, unless a file in the root of the repo
+    called "fail.txt" exists. If present, the check will fail and print a message to the console.
+    """
+
+    name = "SampleCheck"
+    doc = "Sample check that fails if fail.txt exists in the root of the repo"
+
+    def run(self):
+        """
+        Run the sample check.
+        """
+        fail_file = Path(check_compliance.GIT_TOP) / "fail.txt"
+        if fail_file.exists():
+            self.failure("SampleCheck failed because fail.txt exists in the root of the repo.")
+            return False
+
+
+# Run compliance checks using Zephyr's check_compliance.py script
+check_compliance.main(sys.argv[1:])

--- a/scripts/undef_kconfig_allowlist.txt
+++ b/scripts/undef_kconfig_allowlist.txt
@@ -1,0 +1,10 @@
+# List of additional Kconfigs in this repo that
+# should not be flagged as undefined Kconfigs by
+# the CI checks
+BLINK
+BLINK_GPIO_LED
+BLINK_INIT_PRIORITY
+BLINK_LOG_LEVEL
+CUSTOM
+CUSTOM_GET_VALUE_DEFAULT
+EXAMPLE_SENSOR


### PR DESCRIPTION
Add CI job to run compliance script checks within the example repo, as a demonstration of how to utilize and build on Zephyr's compliance checks.

This also enforces the compliance checks on this repo, so we need to reformat a few of the python scripts to comply with them