### PR TITLE
Use zephyr prefix for generated header files

### DIFF
--- a/app/src/main.c
+++ b/app/src/main.c
@@ -9,7 +9,7 @@
 
 #include <app/drivers/blink.h>
 
-#include <app_version.h>
+#include <zephyr/app_version.h>
 
 LOG_MODULE_REGISTER(main, CONFIG_APP_LOG_LEVEL);
 

--- a/include/app/drivers/blink.h
+++ b/include/app/drivers/blink.h
@@ -103,7 +103,7 @@ static inline int blink_off(const struct device *dev)
 	return blink_set_period_ms(dev, 0);
 }
 
-#include <syscalls/blink.h>
+#include <zephyr/syscalls/blink.h>
 
 /** @} */
 

--- a/tests/lib/custom/tests.yaml
+++ b/tests/lib/custom/tests.yaml
@@ -2,7 +2,7 @@ common:
   tags: extensibility
   integration_platforms:
     - custom_plank
-    - qemu_cortex_m0
+    - qemu_cortex_m3
 tests:
   lib.custom: {}
   lib.custom.non_default:


### PR DESCRIPTION
Use zephyr as prefix for the generated header files.