### PR TITLE
Revert "tests: lib: custom: switch to qemu_cortex_m3 as integration platform

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -50,6 +50,6 @@ jobs:
         shell: bash
         run: |
           if [ "${{ runner.os }}" = "Windows" ]; then
-            EXTRA_TWISTER_FLAGS="--short-build-path -O/tmp/twister-out"
+            EXTRA_TWISTER_FLAGS="--short-build-path -O/tmp/twister-out --jobs 1"
           fi
           west twister -T tests -v --inline-logs --integration $EXTRA_TWISTER_FLAGS

--- a/tests/lib/custom/tests.yaml
+++ b/tests/lib/custom/tests.yaml
@@ -2,7 +2,7 @@ common:
   tags: extensibility
   integration_platforms:
     - custom_plank
-    - qemu_cortex_m3
+    - qemu_cortex_m0
 tests:
   lib.custom: {}
   lib.custom.non_default:


### PR DESCRIPTION
This reverts commit 5f333d5114d4ca78ad8e92bc7965758df6fd9038.

QEMU on Windows seems to have concurrency issues, at least for the qemu-cortex-m0 board. Limit the number of concurrent Twister jobs to 1 for now.